### PR TITLE
Fix bind mount in deployment template when persistence disabled

### DIFF
--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -22,16 +22,14 @@ spec:
           image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
           {{- if .Values.extraEnv }}
           env:
-            {{ toYaml .Values.extraEnv | nindent 12 }}
+            {{- toYaml .Values.extraEnv | nindent 12 }}
           {{- end }}
           ports:
             - containerPort: 8000
             - containerPort: 3000
-          {{- if .Values.persistence.enabled }}
           volumeMounts:
             - name: data
               mountPath: /opt/ara
-          {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -39,11 +37,10 @@ spec:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
       volumes:
-      {{- if .Values.persistence.enabled }}
         - name: data
+        {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ include "ara.name" . }}
-      {{- else -}}
-        - name: data
+        {{- else }}
           emptyDir: {}
-      {{- end }}
+        {{- end }}

--- a/templates/ingress.yml
+++ b/templates/ingress.yml
@@ -8,6 +8,9 @@ metadata:
   annotations: {{ toYaml .Values.ingress.annotations | nindent 4 }}
   {{- end }}
 spec:
+{{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
     - hosts:

--- a/values.yaml
+++ b/values.yaml
@@ -1,7 +1,8 @@
 replicas: 1
 
 extraEnv:
-  ARA_ALLOWED_HOSTS: "['localhost', '::1', '127.0.0.1', 'ara.example.com']"
+  - name: ARA_ALLOWED_HOSTS
+    value: '["localhost", "::1", "127.0.0.1", "ara.example.com"]'
 
 deploymentStrategy:
   type: RollingUpdate


### PR DESCRIPTION
Also:
* update the extraEnv syntax (old syntax fails with an error message).
* allow users to override the ingress class